### PR TITLE
Docs update and target only Deno 2+

### DIFF
--- a/.github/workflows/deno-ci.yaml
+++ b/.github/workflows/deno-ci.yaml
@@ -15,13 +15,12 @@ jobs:
     strategy:
       matrix:
         deno-version:
-        - v1.41
-        - v1.43
-        - v1.45
         - v2.0
         - v2.1
         - v2.2
         - v2.3
+        - v2.4
+        - v2.5
         - canary
       fail-fast: false # run each branch to completion
 

--- a/.github/workflows/deno-ci.yaml
+++ b/.github/workflows/deno-ci.yaml
@@ -44,7 +44,7 @@ jobs:
       run: deno install || rm deno.lock
 
     - name: Check mod.ts
-      run: time deno check --unstable-http mod.ts
+      run: time deno check mod.ts
 
     - name: Check demo.ts
       run: time deno check demo.ts

--- a/README.md
+++ b/README.md
@@ -100,8 +100,10 @@ please feel free to file a Github Issue.
     * `v0.7.1` on `2023-09-24`: Update std dependencies to `/std@0.202.0`
     * `v0.7.2` on `2023-12-29`: Fix `WebsocketTunnel` for Deno v1.38 change
     * `v0.7.3` on `2024-09-10`: Drop support for Deno v1.40 and earlier.
-    * `v0.7.3` on `2025-09-18`: Drop `/x/` publication, now JSR-only
-    * `v0.7.4` on `2025-09-19`: Update docs, target only Deno v2.
+    * `v0.7.4` on `2025-04-23`: Add support for relative paths in Kubeconfig (#24, thanks!)
+    * `v0.7.5` on `2025-05-22`: More `abortSignal`, make RestClients closable
+    * `v0.7.6` on `2025-09-18`: Drop `/x/` publication, now JSR-only
+    * `v0.7.7` on `2025-09-19`: Update docs, target only Deno v2.
 
 * `v0.6.0` on `2023-08-08`:
     Introduce an API for opening Kubernetes tunnels, useful for `PodExec` and others.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ please feel free to file a Github Issue.
     * `v0.7.2` on `2023-12-29`: Fix `WebsocketTunnel` for Deno v1.38 change
     * `v0.7.3` on `2024-09-10`: Drop support for Deno v1.40 and earlier.
     * `v0.7.3` on `2025-09-18`: Drop `/x/` publication, now JSR-only
+    * `v0.7.4` on `2025-09-19`: Update docs, target only Deno v2.
 
 * `v0.6.0` on `2023-08-08`:
     Introduce an API for opening Kubernetes tunnels, useful for `PodExec` and others.

--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,7 @@
   "name": "@cloudydeno/kubernetes-client",
   "version": "0.7.6",
   "imports": {
-    "@cloudydeno/stream-observables": "jsr:@cloudydeno/stream-observables@^1.4.1",
+    "@cloudydeno/stream-observables": "jsr:@cloudydeno/stream-observables@^1",
     "@std/path": "jsr:@std/path@^1",
     "@std/streams": "jsr:@std/streams@^1",
     "@std/yaml": "jsr:@std/yaml@^1"
@@ -12,7 +12,9 @@
     "./lib/kubeconfig.ts": "./lib/kubeconfig.ts",
     "./lib/reflector.ts": "./lib/reflector.ts",
     "./lib/stream-transformers.ts": "./lib/stream-transformers.ts",
+    "./transports": "./transports/mod.ts",
     "./transports/mod.ts": "./transports/mod.ts",
+    "./transports/autodetection.ts": "./transports/autodetection.ts",
     "./transports/via-kubeconfig.ts": "./transports/via-kubeconfig.ts",
     "./transports/via-kubectl-raw.ts": "./transports/via-kubectl-raw.ts",
     "./tunnel-beta/via-websocket.ts": "./tunnel-beta/via-websocket.ts",

--- a/deno.lock
+++ b/deno.lock
@@ -1,7 +1,8 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@cloudydeno/stream-observables@^1.4.1": "1.4.1",
+    "jsr:@cloudydeno/stream-observables@1": "1.4.1",
+    "jsr:@std/bytes@^1.0.6": "1.0.6",
     "jsr:@std/internal@^1.0.10": "1.0.10",
     "jsr:@std/path@1": "1.1.2",
     "jsr:@std/streams@1": "1.0.12",
@@ -10,6 +11,9 @@
   "jsr": {
     "@cloudydeno/stream-observables@1.4.1": {
       "integrity": "555aa3d786fcfd066d096fc943ea47afc688618e95146e615705e981008f57c0"
+    },
+    "@std/bytes@1.0.6": {
+      "integrity": "f6ac6adbd8ccd99314045f5703e23af0a68d7f7e58364b47d2c7f408aeb5820a"
     },
     "@std/internal@1.0.10": {
       "integrity": "e3be62ce42cab0e177c27698e5d9800122f67b766a0bea6ca4867886cbde8cf7"
@@ -21,7 +25,10 @@
       ]
     },
     "@std/streams@1.0.12": {
-      "integrity": "ae925fa1dc459b1abf5cbaa28cc5c7b0485853af3b2a384b0dc22d86e59dfbf4"
+      "integrity": "ae925fa1dc459b1abf5cbaa28cc5c7b0485853af3b2a384b0dc22d86e59dfbf4",
+      "dependencies": [
+        "jsr:@std/bytes"
+      ]
     },
     "@std/yaml@1.0.9": {
       "integrity": "6bad3dc766dd85b4b37eabcba81b6aa4eac7a392792ae29abcfb0f90602d55bb"
@@ -29,7 +36,7 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@cloudydeno/stream-observables@^1.4.1",
+      "jsr:@cloudydeno/stream-observables@1",
       "jsr:@std/path@1",
       "jsr:@std/streams@1",
       "jsr:@std/yaml@1"

--- a/examples/get-resource.ts
+++ b/examples/get-resource.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run --unstable-http --allow-env --allow-read=/var/run/secrets/kubernetes.io
+#!/usr/bin/env -S deno run --allow-env --allow-read=/var/run/secrets/kubernetes.io
 
 import { autoDetectClient } from '../mod.ts';
 

--- a/examples/stream-logs.ts
+++ b/examples/stream-logs.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run --unstable --allow-env
+#!/usr/bin/env -S deno run --allow-env --allow-read=/var/run/secrets/kubernetes.io
 
 import { TextLineStream } from '@std/streams/text-line-stream';
 import { autoDetectClient } from '../mod.ts';

--- a/examples/watch-resources.ts
+++ b/examples/watch-resources.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run --unstable --allow-env
+#!/usr/bin/env -S deno run --allow-env --allow-read=/var/run/secrets/kubernetes.io
 
 import { autoDetectClient } from '../mod.ts';
 

--- a/transports/autodetection.ts
+++ b/transports/autodetection.ts
@@ -1,0 +1,71 @@
+import { KubectlRawRestClient } from './via-kubectl-raw.ts';
+import { KubeConfigRestClient } from './via-kubeconfig.ts';
+
+import type { RestClient } from '../lib/contract.ts';
+
+type ClientProvider = () => Promise<RestClient>;
+export class ClientProviderChain {
+  constructor(
+    public chain: Array<[string, ClientProvider]>,
+  ) {}
+  async getClient(): Promise<RestClient> {
+    const errors: Array<string> = [];
+    for (const [label, factory] of this.chain) {
+      try {
+        const creds = await factory();
+        const {kind} = await creds.performRequest({
+          method: 'GET',
+          path: '/api?healthcheck',
+          expectJson: true,
+        }) as { kind?: string };
+        if (kind !== 'APIVersions') throw new Error(
+          `Didn't see a Kubernetes API surface at /api`);
+        return creds;
+      } catch (err) {
+        const srcName = `  - ${label} `;
+        if (err instanceof Error) {
+          errors.push(srcName+(err.stack?.split('\n')[0] || err.message));
+        } else if (err) {
+          errors.push(srcName+err.toString());
+        }
+      }
+    }
+    return Promise.reject(new Error([
+      `Failed to load any possible Kubernetes clients:`,
+    ...errors].join('\n')));
+  }
+}
+
+/** Constructs the typical list of Kubernetes API clients,
+ * using an alternative client for connecting to KubeConfig contexts.
+ * The Kubectl client is unaffected by this. */
+export function makeClientProviderChain(restClientFactory: KubeConfigClientFactory): ClientProviderChain {
+  return new ClientProviderChain([
+    ['InCluster', () => restClientFactory.forInCluster()],
+    ['KubeConfig', () => restClientFactory.readKubeConfig()],
+    ['KubectlProxy', () => restClientFactory.forKubectlProxy()],
+    ['KubectlRaw', () => Promise.resolve(new KubectlRawRestClient())],
+  ]);
+}
+
+/** A subset of KubeConfigRestClient's static interface. */
+interface KubeConfigClientFactory {
+  forInCluster(): Promise<RestClient>;
+  forKubectlProxy(): Promise<RestClient>;
+  readKubeConfig(
+    path?: string,
+    contextName?: string,
+  ): Promise<RestClient>;
+}
+
+export const DefaultClientProvider: ClientProviderChain = makeClientProviderChain(KubeConfigRestClient);
+
+/**
+ * Automatic trial-and-error approach for deciding how to talk to Kubernetes.
+ * Influenced by Deno's current permissions and Deno may prompt for more permissions.
+ * Will emit a list of problems if no usable clients are found.
+ * You'll likely want to set the correct Deno permissions for your installation.
+ */
+export async function autoDetectClient(): Promise<RestClient> {
+  return await DefaultClientProvider.getClient();
+}

--- a/transports/mod.ts
+++ b/transports/mod.ts
@@ -1,74 +1,9 @@
-import { KubectlRawRestClient } from './via-kubectl-raw.ts';
-import { KubeConfigRestClient } from './via-kubeconfig.ts';
-export { KubectlRawRestClient, KubeConfigRestClient };
+export { KubectlRawRestClient } from './via-kubectl-raw.ts';
+export { KubeConfigRestClient } from './via-kubeconfig.ts';
 
-import type { RestClient } from '../lib/contract.ts';
-
-type ClientProvider = () => Promise<RestClient>;
-export class ClientProviderChain {
-  constructor(
-    public chain: Array<[string, ClientProvider]>,
-  ) {}
-  async getClient(): Promise<RestClient> {
-    const errors: Array<string> = [];
-    for (const [label, factory] of this.chain) {
-      try {
-        const creds = await factory();
-        const {kind} = await creds.performRequest({
-          method: 'GET',
-          path: '/api?healthcheck',
-          expectJson: true,
-        }) as { kind?: string };
-        if (kind !== 'APIVersions') throw new Error(
-          `Didn't see a Kubernetes API surface at /api`);
-        return creds;
-      } catch (err) {
-        const srcName = `  - ${label} `;
-        if (err instanceof Error) {
-          // if (err.message !== 'No credentials found') {
-            errors.push(srcName+(err.stack?.split('\n')[0] || err.message));
-          // }
-        } else if (err) {
-          errors.push(srcName+err.toString());
-        }
-      }
-    }
-    return Promise.reject(new Error([
-      `Failed to load any possible Kubernetes clients:`,
-    ...errors].join('\n')));
-  }
-}
-
-/** Constructs the typical list of Kubernetes API clients,
- * using an alternative client for connecting to KubeConfig contexts.
- * The Kubectl client is unaffected by this. */
-export function makeClientProviderChain(restClientFactory: KubeConfigClientFactory): ClientProviderChain {
-  return new ClientProviderChain([
-    ['InCluster', () => restClientFactory.forInCluster()],
-    ['KubeConfig', () => restClientFactory.readKubeConfig()],
-    ['KubectlProxy', () => restClientFactory.forKubectlProxy()],
-    ['KubectlRaw', () => Promise.resolve(new KubectlRawRestClient())],
-  ]);
-}
-
-/** A subset of KubeConfigRestClient's static interface. */
-interface KubeConfigClientFactory {
-  forInCluster(): Promise<RestClient>;
-  forKubectlProxy(): Promise<RestClient>;
-  readKubeConfig(
-    path?: string,
-    contextName?: string,
-  ): Promise<RestClient>;
-}
-
-export const DefaultClientProvider: ClientProviderChain = makeClientProviderChain(KubeConfigRestClient);
-
-/**
- * Automatic trial-and-error approach for deciding how to talk to Kubernetes.
- * Influenced by Deno's current permissions and Deno may prompt for more permissions.
- * Will emit a list of problems if no usable clients are found.
- * You'll likely want to set the correct Deno permissions for your installation.
- */
-export async function autoDetectClient(): Promise<RestClient> {
-  return await DefaultClientProvider.getClient();
-}
+export {
+  ClientProviderChain,
+  makeClientProviderChain,
+  DefaultClientProvider,
+  autoDetectClient,
+} from './autodetection.ts';

--- a/transports/via-kubeconfig.ts
+++ b/transports/via-kubeconfig.ts
@@ -17,12 +17,9 @@ const isVerbose = Deno.args.includes('--verbose');
  *
  * Deno flags to use this client:
  * Basic KubeConfig: --allow-read=$HOME/.kube --allow-net --allow-env
- * CA cert fix: --unstable-http --allow-read=$HOME/.kube --allow-net --allow-env
- * In-cluster 1: --allow-read=/var/run/secrets/kubernetes.io --allow-net --unstable-http
- * In-cluster 2: --allow-read=/var/run/secrets/kubernetes.io --allow-net --cert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+ * In-cluster: --allow-read=/var/run/secrets/kubernetes.io --allow-net
  *
  * Unstable features:
- * - using the cluster's CA when fetching (otherwise pass --cert to Deno)
  * - using client auth authentication, if configured
  * - inspecting permissions and prompting for further permissions (TODO)
  *
@@ -80,14 +77,14 @@ export class KubeConfigRestClient implements RestClient {
       if (Deno.createHttpClient) {
         httpClient = Deno.createHttpClient({
           caCerts: serverTls ? [serverTls.serverCert] : [],
-          //@ts-ignore-error deno unstable API. Not typed?
           cert: tlsAuth?.userCert,
           key: tlsAuth?.userKey,
         });
       } else if (tlsAuth) {
-        console.error('WARN: cannot use certificate-based auth without --unstable');
+        console.error('WARN: cannot use certificate-based auth without --unstable-http');
       } else if (isVerbose) {
-        console.error('WARN: cannot have Deno trust the server CA without --unstable');
+        // This is no longer true:
+        console.error('WARN: cannot have Deno trust the server CA without --unstable-http');
       }
     }
 

--- a/tunnel-beta/examples/ws-exec-poc.ts
+++ b/tunnel-beta/examples/ws-exec-poc.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run --unstable-net --allow-env --allow-read --allow-net --cert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+#!/usr/bin/env -S deno run --allow-env --allow-read --allow-net
 
 import { WebsocketRestClient } from "../via-websocket.ts";
 

--- a/tunnel-beta/via-spdy-transport.ts
+++ b/tunnel-beta/via-spdy-transport.ts
@@ -25,7 +25,6 @@ export class SpdyEnabledRestClient extends KubeConfigRestClient {
       port: url.port ? parseInt(url.port) : 443,
       alpnProtocols: ['http/1.1'],
       caCerts: serverTls?.serverCert ? [serverTls.serverCert] : [],
-      //@ts-ignore-error deno unstable API. Not typed?
       cert: clientTls?.userCert,
       key: clientTls?.userKey,
     });


### PR DESCRIPTION
Cleans up some guidance and workarounds that are no longer relevant in recent Deno versions.

Also moves the client detection logic into a dedicated file.